### PR TITLE
[codex] 性能优化：降低本地调度额外开销

### DIFF
--- a/docs/superpowers/specs/2026-04-04-local-scheduler-performance-design.md
+++ b/docs/superpowers/specs/2026-04-04-local-scheduler-performance-design.md
@@ -1,0 +1,53 @@
+# Local Scheduler Performance Design
+
+## Goal
+
+Optimize local single-machine scheduling throughput and idle overhead without changing the project's external API, task model, status model, or feature boundary.
+
+## Scope
+
+In scope:
+
+- `task_scheduling/manager/scheduler_manager.py`
+- `task_scheduling/scheduler/api.py`
+- local scheduler internals in `task_scheduling/scheduler/`
+- regression tests for unchanged behavior
+
+Out of scope:
+
+- RPC, proxy, result server, and Web UI behavior
+- changing task priority semantics
+- changing public configuration keys
+- adding new runtime dependencies
+
+## Problems Observed
+
+1. `TaskScheduler.add_task()` increments `_task_counter` but never resets it, so after 40 submissions every new task can trigger `gc.collect()`. This directly hurts burst submit throughput.
+2. Several schedulers rebuild `running_task_names` from `_running_tasks` during every `add_task()` call. This makes the hot add path scale with the number of currently running tasks.
+3. `scheduler_manager._allocator()` and some scheduler loops use `empty()` plus follow-up queue operations and timeout-based waiting. This adds avoidable wakeups and can create unnecessary contention in idle and burst scenarios.
+4. `cleanup_results_api()` copies whole result dictionaries before pruning. That adds avoidable allocation and lock time under result pressure.
+
+## Chosen Approach
+
+Use narrow internal optimizations only:
+
+- make GC triggering periodic instead of permanently hot
+- maintain running task names incrementally instead of rebuilding transient sets
+- switch hot queue consumers to blocking/event-driven retrieval where possible
+- prune result dictionaries in place under lock
+
+This keeps all external behavior intact while reducing unnecessary work on the submit and idle paths.
+
+## Safety Constraints
+
+- task acceptance and rejection rules must remain unchanged
+- same-name concurrency blocking must remain unchanged
+- scheduler shutdown and idle timeout behavior must remain unchanged
+- task status transitions must remain compatible with current consumers
+
+## Validation
+
+- add `unittest` coverage for the GC threshold fix
+- add `unittest` coverage for same-name rejection without rebuilding transient sets
+- add `unittest` coverage for allocator blocking behavior and cleanup thread single-start behavior where practical
+- run the focused test module with `python -m unittest`

--- a/task_scheduling/manager/scheduler_manager.py
+++ b/task_scheduling/manager/scheduler_manager.py
@@ -26,7 +26,7 @@ class TaskScheduler:
                  'allocator_running', 'allocator_started', 'allocator_thread',
                  '_task_event', '_lock', '_shutdown_lock',
                  '_allow_task_addition',
-                 '_task_counter']
+                 '_task_counter', '_gc_interval']
 
     def __init__(self) -> None:
         self.ban_task_names: List[str] = []
@@ -39,6 +39,7 @@ class TaskScheduler:
         self._shutdown_lock = threading.Lock()  # Lock for shutdown operation
         self._allow_task_addition: bool = True
         self._task_counter: int = 0
+        self._gc_interval: int = 40
 
     def add_task(self,
                  delay: Union[int, None],
@@ -93,8 +94,9 @@ class TaskScheduler:
                                       args,
                                       kwargs))
             self._task_counter += 1
-            if self._task_counter >= 40:
+            if self._task_counter >= self._gc_interval:
                 logger.warning(f"Garbage collection performed. A total of <{gc.collect()}> objects were recycled.")
+                self._task_counter = 0
 
             self._task_event.set()  # Wake up the allocator thread
             task_status_manager.add_task_status(task_id, task_name, "queuing", None, None, None, timeout_processing,
@@ -110,75 +112,79 @@ class TaskScheduler:
 
     def _allocator(self) -> None:
         # Avoid import issues
-        from task_scheduling.scheduler import add_api, cleanup_results_api
+        from task_scheduling.scheduler.api import add_api, ensure_cleanup_results_thread_started
 
-        threading.Thread(target=cleanup_results_api, daemon=True).start()
+        ensure_cleanup_results_thread_started()
 
         while self.allocator_running:
             if not self._allow_task_addition:
-                time.sleep(0.1)
+                self._task_event.clear()
+                if self.allocator_running and not self._allow_task_addition:
+                    self._task_event.wait(timeout=0.1)
                 continue
 
-            if not self.core_task_queue.empty():
+            try:
                 (delay, daily_time, async_function, function_type, timeout_processing, task_name, task_id, func,
-                 priority,
-                 args, kwargs) = self.core_task_queue.get()
-                state = False
+                 priority, args, kwargs) = self.core_task_queue.get_nowait()
+            except queue.Empty:
+                self._task_event.clear()
+                if self.allocator_running and self.core_task_queue.empty():
+                    self._task_event.wait()
+                continue
 
-                if async_function:
+            state = False
 
-                    if function_type == "io":
-                        state = add_api("io_asyncio_task", None, None, timeout_processing, task_name, task_id, func,
-                                        priority, *args, **kwargs)
-                    if function_type == "cpu":
-                        state = add_api("cpu_asyncio_task", None, None, timeout_processing, task_name, task_id, func,
-                                        priority, *args, **kwargs)
+            if async_function:
+
+                if function_type == "io":
+                    state = add_api("io_asyncio_task", None, None, timeout_processing, task_name, task_id, func,
+                                    priority, *args, **kwargs)
+                if function_type == "cpu":
+                    state = add_api("cpu_asyncio_task", None, None, timeout_processing, task_name, task_id, func,
+                                    priority, *args, **kwargs)
+
+            if not async_function:
+
+                if function_type == "io":
+                    state = add_api("io_liner_task", None, None, timeout_processing, task_name, task_id, func,
+                                    priority, *args, **kwargs)
+                if function_type == "cpu":
+                    state = add_api("cpu_liner_task", None, None, timeout_processing, task_name, task_id, func,
+                                    priority, *args, **kwargs)
+
+            if function_type == "timer":
 
                 if not async_function:
+                    state = add_api("timer_task", delay, daily_time, timeout_processing, task_name, task_id, func,
+                                    priority, *args, **kwargs)
+                else:
+                    logger.warning("The timer function cannot be asynchronous code!")
+                    state = "The timer function cannot be asynchronous code!"
 
-                    if function_type == "io":
-                        state = add_api("io_liner_task", None, None, timeout_processing, task_name, task_id, func,
-                                        priority, *args, **kwargs)
-                    if function_type == "cpu":
-                        state = add_api("cpu_liner_task", None, None, timeout_processing, task_name, task_id, func,
-                                        priority, *args, **kwargs)
+            if state == False:
+                self.core_task_queue.put((delay,
+                                          daily_time,
+                                          async_function,
+                                          function_type,
+                                          timeout_processing,
+                                          task_name,
+                                          task_id,
+                                          func,
+                                          priority,
+                                          args,
+                                          kwargs))
+                time.sleep(0.01)
 
-                if function_type == "timer":
-
-                    if not async_function:
-                        state = add_api("timer_task", delay, daily_time, timeout_processing, task_name, task_id, func,
-                                        priority, *args, **kwargs)
-                    else:
-                        logger.warning("The timer function cannot be asynchronous code!")
-                        state = "The timer function cannot be asynchronous code!"
-
-                if state == False:
-                    self.core_task_queue.put((delay,
-                                              daily_time,
-                                              async_function,
-                                              function_type,
-                                              timeout_processing,
-                                              task_name,
-                                              task_id,
-                                              func,
-                                              priority,
-                                              args,
-                                              kwargs))
-
-                if not state == False and not state == True:
-                    task_status_manager.add_task_status(task_id, None, "failed", None, None, state,
-                                                        timeout_processing, None)
-
-            else:
-                self._task_event.clear()
-                if self.core_task_queue.empty():
-                    self._task_event.wait()  # Wait for the event to trigger
+            if not state == False and not state == True:
+                task_status_manager.add_task_status(task_id, None, "failed", None, None, state,
+                                                    timeout_processing, None)
 
     def _stop_task_addition(self) -> None:
         """
         Stop task addition by banning all task names
         """
         self._allow_task_addition = False
+        self._task_event.set()
         logger.warning(f"Task addition was disabled by user!")
 
     def _resume_task_addition(self) -> None:
@@ -186,6 +192,7 @@ class TaskScheduler:
         Resume task addition by removing all bans
         """
         self._allow_task_addition = True
+        self._task_event.set()
         logger.warning(f"Task addition was enabled by user!")
 
     def cancel_the_queue_task_by_name(self, task_name: str) -> None:

--- a/task_scheduling/scheduler/api.py
+++ b/task_scheduling/scheduler/api.py
@@ -6,6 +6,7 @@ This module provides a unified API for managing different types of tasks
 (IO-bound, CPU-bound, timer) with support for asynchronous and linear execution modes.
 """
 import time
+import threading
 from typing import Any, Union, Callable
 
 from task_scheduling.common import logger, config
@@ -23,6 +24,9 @@ _TASK_HANDLERS = {
     "cpu_asyncio_task": cpu_asyncio_task,
     "timer_task": timer_task,
 }
+
+_cleanup_thread = None
+_cleanup_thread_lock = threading.Lock()
 
 
 def _get_handler(task_type: str):
@@ -125,29 +129,59 @@ def get_result_api(task_type: str, task_id: str) -> Any:
     return handler.get_task_result(task_id)
 
 
+def _cleanup_task_results(handler: Any,
+                          current_time: Union[float, None] = None,
+                          max_result_count: Union[int, None] = None,
+                          max_result_age: Union[int, None] = None) -> None:
+    """
+    Remove expired task results in place for a single handler.
+
+    Args:
+        handler: Scheduler handler containing `_task_results` and `_lock`.
+        current_time: Timestamp used for age comparison.
+        max_result_count: Threshold that enables cleanup.
+        max_result_age: Maximum retained result age in seconds.
+    """
+    if current_time is None:
+        current_time = time.time()
+    if max_result_count is None:
+        max_result_count = config["maximum_result_storage"]
+    if max_result_age is None:
+        max_result_age = config["maximum_result_time_storage"]
+
+    with handler._lock:
+        if len(handler._task_results) < max_result_count:
+            return
+
+        expired_task_ids = [
+            task_id for task_id, value in handler._task_results.items()
+            if int(current_time - value[1]) >= max_result_age
+        ]
+        for task_id in expired_task_ids:
+            handler._task_results.pop(task_id, None)
+
+
+def ensure_cleanup_results_thread_started() -> None:
+    """
+    Start the cleanup thread once for the current process.
+    """
+    global _cleanup_thread
+
+    with _cleanup_thread_lock:
+        if _cleanup_thread is not None and _cleanup_thread.is_alive():
+            return
+
+        _cleanup_thread = threading.Thread(target=cleanup_results_api, daemon=True)
+        _cleanup_thread.start()
+
+
 def cleanup_results_api() -> None:
     """
     Clear useless return results.
     """
-    max_result_count = config["maximum_result_storage"]
     while True:
         for handler in _TASK_HANDLERS.values():
-            del_task_results = []
-            # Check if the cleaning limit has been reached
-            if len(handler._task_results) >= max_result_count:
-                # Lock
-                with handler._lock:
-                    cache_task_results = handler._task_results.copy()
-                # Delete results that have been inactive for too long
-                for key, value in cache_task_results.items():
-                    if int(time.time() - value[1]) >= config["maximum_result_time_storage"]:
-                        del_task_results.append(key)
-                # Delete the data for 'drinking' in the dictionary
-                for task_id in del_task_results:
-                    del cache_task_results[task_id]
-                # Lock
-                with handler._lock:
-                    handler._task_results = cache_task_results
+            _cleanup_task_results(handler)
         try:
             time.sleep(2.0)
         except KeyboardInterrupt:

--- a/task_scheduling/scheduler/cpu_asyncio_task.py
+++ b/task_scheduling/scheduler/cpu_asyncio_task.py
@@ -131,7 +131,7 @@ class CpuAsyncioTask:
     Linear task manager class, responsible for managing the scheduling, execution, and monitoring of linear tasks.
     """
     __slots__ = [
-        '_task_queue', '_running_tasks',
+        '_task_queue', '_running_tasks', '_running_task_names',
         '_lock', '_condition', '_scheduler_lock',
         '_scheduler_started', '_scheduler_stop_event', '_scheduler_thread',
         '_idle_timer', '_idle_timeout', '_idle_timer_lock',
@@ -145,6 +145,7 @@ class CpuAsyncioTask:
         """
         self._task_queue = queue.Queue()  # Task queue
         self._running_tasks = {}  # Running tasks
+        self._running_task_names = set()  # Running task names for O(1) duplicate checks
 
         self._lock = threading.Lock()  # Lock to protect access to shared resources
         self._scheduler_lock = threading.RLock()  # Reentrant lock for scheduler operations
@@ -203,10 +204,9 @@ class CpuAsyncioTask:
             # 1. Capacity check (lock only for shared state)
             with self._lock:
                 queue_size = self._task_queue.qsize()
-                running_task_names = {details[1] for details in self._running_tasks.values()}
                 if queue_size >= config["cpu_asyncio_task"] or len(self._running_tasks) >= config["cpu_asyncio_task"]:
                     return False
-                if task_name in running_task_names:
+                if task_name in self._running_task_names:
                     return False
 
             # 2. Status updates (queue is thread-safe)
@@ -295,6 +295,7 @@ class CpuAsyncioTask:
             with self._lock:
                 self._scheduler_started = False
                 self._running_tasks.clear()
+                self._running_task_names.clear()
                 self._task_results.clear()
 
             self._scheduler_thread = None
@@ -330,16 +331,15 @@ class CpuAsyncioTask:
                 with self._condition:
                     while (self._task_queue.empty() and
                            not self._scheduler_stop_event.is_set()):
-                        self._condition.wait(timeout=1.0)
+                        self._condition.wait()
 
                     if self._scheduler_stop_event.is_set():
                         break
 
-                    if self._task_queue.empty():
+                    try:
+                        task = self._task_queue.get_nowait()
+                    except queue.Empty:
                         continue
-
-                    # Atomically get a task from the queue (inside lock)
-                    task = self._task_queue.get()
 
                 if task is None:
                     continue
@@ -353,6 +353,7 @@ class CpuAsyncioTask:
                                              shared_status_info_asyncio.task_pid)
                     with self._lock:
                         self._running_tasks[task_id] = [future, task_name]
+                        self._running_task_names.add(task_name)
 
                     future.add_done_callback(partial(self._task_done, task_id))
                 except Exception as error:
@@ -409,8 +410,9 @@ class CpuAsyncioTask:
                         self._task_results[task_id] = [result, time.time()]
 
                 # Remove from running tasks
-                if task_id in self._running_tasks:
-                    del self._running_tasks[task_id]
+                task_info = self._running_tasks.pop(task_id, None)
+                if task_info is not None:
+                    self._running_task_names.discard(task_info[1])
 
                 # Check if all tasks are completed
                 if self._task_queue.empty() and len(self._running_tasks) == 0:

--- a/task_scheduling/scheduler/cpu_liner_task.py
+++ b/task_scheduling/scheduler/cpu_liner_task.py
@@ -141,7 +141,7 @@ class CpuLinerTask:
     Linear task manager class, responsible for managing the scheduling, execution, and monitoring of linear tasks.
     """
     __slots__ = [
-        '_task_queue', '_running_tasks',
+        '_task_queue', '_running_tasks', '_running_task_names',
         '_lock', '_condition', '_scheduler_lock',
         '_scheduler_started', '_scheduler_stop_event', '_scheduler_thread',
         '_idle_timer', '_idle_timeout', '_idle_timer_lock',
@@ -155,6 +155,7 @@ class CpuLinerTask:
         """
         self._task_queue = queue.Queue()  # Task queue
         self._running_tasks = {}  # Running tasks
+        self._running_task_names = set()  # Running task names for O(1) duplicate checks
 
         self._lock = threading.Lock()  # Lock to protect access to shared resources
         self._scheduler_lock = threading.RLock()  # Reentrant lock for scheduler operations
@@ -221,7 +222,6 @@ class CpuLinerTask:
             with self._lock:
 
                 queue_size = self._task_queue.qsize()
-                running_task_names = {details[1] for details in self._running_tasks.values()}
                 if queue_size >= config["cpu_liner_task"] or len(self._running_tasks) >= config["cpu_liner_task"]:
                     if not _task_counter.is_high_priority(priority):
                         if _task_counter.is_high_priority_full(config["cpu_liner_task"]):
@@ -229,7 +229,7 @@ class CpuLinerTask:
                         need_add_high = True
                     return False
 
-                if task_name in running_task_names:
+                if task_name in self._running_task_names:
                     return False
 
             if need_add_high:
@@ -318,6 +318,7 @@ class CpuLinerTask:
             with self._lock:
                 self._scheduler_started = False
                 self._running_tasks.clear()
+                self._running_task_names.clear()
                 self._task_results.clear()
 
             self._scheduler_thread = None
@@ -355,16 +356,15 @@ class CpuLinerTask:
                 with self._condition:
                     while (self._task_queue.empty() and
                            not self._scheduler_stop_event.is_set()):
-                        self._condition.wait(timeout=1.0)
+                        self._condition.wait()
 
                     if self._scheduler_stop_event.is_set():
                         break
 
-                    if self._task_queue.empty():
+                    try:
+                        task = self._task_queue.get_nowait()
+                    except queue.Empty:
                         continue
-
-                    # Atomically get a task from the queue (inside lock)
-                    task = self._task_queue.queue[0]
 
                 # Now task is taken out of queue, lock released
                 if task is None:
@@ -379,7 +379,7 @@ class CpuLinerTask:
                                              shared_status_info_liner.task_pid)
                     with self._lock:
                         self._running_tasks[task_id] = [future, task_name, priority]
-                    self._task_queue.get()
+                        self._running_task_names.add(task_name)
 
                     future.add_done_callback(partial(self._task_done, task_id))
                 except Exception as error:
@@ -441,8 +441,9 @@ class CpuLinerTask:
                         self._task_results[task_id] = [result, time.time()]
 
                 # Remove from running tasks
-                if task_id in self._running_tasks:
-                    del self._running_tasks[task_id]
+                task_info = self._running_tasks.pop(task_id, None)
+                if task_info is not None:
+                    self._running_task_names.discard(task_info[1])
 
                 # Check if all tasks are completed
                 if self._task_queue.empty() and len(self._running_tasks) == 0:

--- a/task_scheduling/scheduler/io_asyncio_task.py
+++ b/task_scheduling/scheduler/io_asyncio_task.py
@@ -342,8 +342,9 @@ class IoAsyncioTask:
         while not self._scheduler_stop_events[task_name].is_set():
             with self._lock:
                 # Use loop and timeout to prevent spurious wakeup
-                while task_name not in self._task_queues or self._task_queues[task_name].empty():
-                    self._lock.wait(timeout=1.0)  # Add timeout to prevent permanent waiting
+                while (not self._scheduler_stop_events[task_name].is_set() and
+                       (task_name not in self._task_queues or self._task_queues[task_name].empty())):
+                    self._lock.wait()
 
                 if self._scheduler_stop_events[task_name].is_set():
                     break
@@ -353,7 +354,10 @@ class IoAsyncioTask:
                         self._task_queues[task_name].empty()):
                     continue
 
-                task = self._task_queues[task_name].queue[0]
+                try:
+                    task = self._task_queues[task_name].get_nowait()
+                except queue.Empty:
+                    continue
 
             # Execute the task after the lock is released
             timeout_processing, task_name, task_id, func, args, kwargs = task
@@ -363,7 +367,6 @@ class IoAsyncioTask:
             # Use lock protection for shared state updates (fast operation)
             with self._lock:
                 self._running_tasks[task_id] = [future, task_name]
-            self._task_queues[task_name].get()
             future.add_done_callback(partial(self._task_done, task_id, task_name))
 
     def _task_done(self,

--- a/task_scheduling/scheduler/io_liner_task.py
+++ b/task_scheduling/scheduler/io_liner_task.py
@@ -99,7 +99,7 @@ class IoLinerTask:
     Linear task manager class, responsible for managing the scheduling, execution, and monitoring of linear tasks.
     """
     __slots__ = [
-        '_task_queue', '_running_tasks',
+        '_task_queue', '_running_tasks', '_running_task_names',
         '_lock', '_condition', '_scheduler_lock',
         '_scheduler_started', '_scheduler_stop_event', '_scheduler_thread',
         '_idle_timer', '_idle_timeout', '_idle_timer_lock',
@@ -114,6 +114,7 @@ class IoLinerTask:
 
         self._task_queue = queue.Queue()  # Task queue
         self._running_tasks = {}  # Running tasks
+        self._running_task_names = set()  # Running task names for O(1) duplicate checks
 
         self._lock = threading.Lock()  # Lock to protect access to shared resources
         self._scheduler_lock = threading.RLock()  # Reentrant lock for scheduler operations
@@ -161,7 +162,6 @@ class IoLinerTask:
             with self._lock:
                 # Atomic Check Queue Size and Running Tasks
                 queue_size = self._task_queue.qsize()
-                running_task_names = {details[1] for details in self._running_tasks.values()}
 
                 if queue_size >= config["io_liner_task"] or len(self._running_tasks) >= config[
                     "io_liner_task"]:
@@ -172,7 +172,7 @@ class IoLinerTask:
                         need_add_high = True
                     return False
 
-                if task_name in running_task_names:
+                if task_name in self._running_task_names:
                     return False
 
             if need_add_high:
@@ -247,6 +247,7 @@ class IoLinerTask:
             with self._lock:
                 self._scheduler_started = False
                 self._running_tasks.clear()
+                self._running_task_names.clear()
                 self._task_results.clear()
 
             self._scheduler_thread = None
@@ -289,16 +290,16 @@ class IoLinerTask:
                     # Use loops and timeouts to prevent spurious wakeup
                     while (self._task_queue.empty() and
                            not self._scheduler_stop_event.is_set()):
-                        self._condition.wait(timeout=1.0)  # Add a timeout to prevent waiting indefinitely
+                        self._condition.wait()
 
                     if self._scheduler_stop_event.is_set():
                         break
 
                     # Check the queue status again, as it may have been falsely awakened or timed out.
-                    if self._task_queue.empty():
+                    try:
+                        task = self._task_queue.get_nowait()
+                    except queue.Empty:
                         continue
-
-                    task = self._task_queue.queue[0]
 
                 timeout_processing, task_name, task_id, func, priority, args, kwargs = task
 
@@ -306,7 +307,7 @@ class IoLinerTask:
                 future = executor.submit(_execute_task, task)
                 with self._lock:
                     self._running_tasks[task_id] = [future, task_name, priority]
-                self._task_queue.get()
+                    self._running_task_names.add(task_name)
 
                 future.add_done_callback(partial(self._task_done, task_id))
 
@@ -357,8 +358,9 @@ class IoLinerTask:
                         self._task_results[task_id] = [result, time.time()]
 
                 # Remove from the running task dictionary
-                if task_id in self._running_tasks:
-                    del self._running_tasks[task_id]
+                task_info = self._running_tasks.pop(task_id, None)
+                if task_info is not None:
+                    self._running_task_names.discard(task_info[1])
 
                 # Check if all tasks are completed
                 if self._task_queue.empty() and len(self._running_tasks) == 0:

--- a/tests/test_local_scheduler_performance.py
+++ b/tests/test_local_scheduler_performance.py
@@ -1,0 +1,100 @@
+import importlib
+import sys
+import threading
+import types
+import unittest
+from unittest import mock
+
+import loguru
+
+
+def _load_module(module_name):
+    sys.modules["dill"] = types.SimpleNamespace(
+        dumps=lambda value: value,
+        loads=lambda value: value,
+    )
+    loguru.logger.add = lambda *args, **kwargs: 1
+    loguru.logger.remove = lambda *args, **kwargs: None
+    return importlib.import_module(module_name)
+
+
+class TaskSchedulerGcTests(unittest.TestCase):
+    def test_gc_runs_once_per_threshold_window(self):
+        scheduler_manager = _load_module("task_scheduling.manager.scheduler_manager")
+        scheduler = scheduler_manager.TaskScheduler()
+        scheduler.allocator_started = True
+
+        with mock.patch.object(
+            type(scheduler_manager.task_status_manager),
+            "add_task_status",
+            return_value=None,
+        ), mock.patch.object(scheduler_manager.gc, "collect", return_value=0) as collect_mock:
+            for index in range(41):
+                added = scheduler.add_task(
+                    None,
+                    None,
+                    False,
+                    "io",
+                    False,
+                    f"task-{index}",
+                    f"id-{index}",
+                    lambda: None,
+                    "low",
+                )
+                self.assertTrue(added)
+
+        self.assertEqual(collect_mock.call_count, 1)
+        self.assertEqual(scheduler._task_counter, 1)
+
+
+class CleanupResultsTests(unittest.TestCase):
+    def test_cleanup_prunes_expired_results_in_place(self):
+        scheduler_api = _load_module("task_scheduling.scheduler.api")
+
+        class DummyHandler:
+            def __init__(self):
+                self._lock = threading.Lock()
+                self._task_results = {
+                    "expired": ["old", 10],
+                    "fresh": ["new", 90],
+                }
+
+        handler = DummyHandler()
+        original_mapping = handler._task_results
+
+        scheduler_api._cleanup_task_results(
+            handler,
+            current_time=100,
+            max_result_count=1,
+            max_result_age=20,
+        )
+
+        self.assertIs(handler._task_results, original_mapping)
+        self.assertEqual(handler._task_results, {"fresh": ["new", 90]})
+
+
+class RunningTaskNameIndexTests(unittest.TestCase):
+    def test_io_liner_rejects_duplicate_name_from_running_name_index(self):
+        io_liner_module = _load_module("task_scheduling.scheduler.io_liner_task")
+        scheduler = io_liner_module.IoLinerTask()
+        scheduler._scheduler_started = True
+        scheduler._running_task_names.add("duplicate-name")
+
+        with mock.patch.object(
+            type(io_liner_module.task_status_manager),
+            "add_task_status",
+            return_value=None,
+        ):
+            added = scheduler.add_task(
+                False,
+                "duplicate-name",
+                "task-id",
+                lambda: None,
+                "low",
+            )
+
+        self.assertFalse(added)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 这个 PR 做了什么

这个 PR 只优化了本地单机调度这一条路径。

没有改 public API，没有改任务类型，没有改任务状态模型，也没有改 RPC、proxy、Web UI 这些能力边界。目标很单纯，就是把本地调度路径里一些可以避免的额外开销拿掉，同时尽量不改变现在的行为和原本设计意图。

## 为什么要改

我在看本地调度代码时，发现有几处地方会在不改变功能的前提下，多做不少额外工作：

1. `TaskScheduler.add_task()` 里的 `_task_counter` 只会一直增加，不会重置。
   这样一旦超过 GC 阈值，后面每次继续提交任务，都可能触发一次 `gc.collect()`。
   在高频提交任务时，这会让热路径越来越重。

2. 几个本地 scheduler 在每次 `add_task()` 时，都会临时重建一份 `running_task_names` 集合来判断“同名任务是否正在运行”。
   这意味着任务越多，提交路径上这一步的额外成本也越高。

3. 部分 scheduler 循环是靠超时唤醒，以及 `queue[0]` 再 `get()` 的方式工作。
   这样会带来一些不必要的空转唤醒和队列竞争。

4. 结果清理时，会先把整个结果字典复制一份，再删除过期数据。
   当结果较多时，这会增加额外的内存分配和锁占用时间。

## 这次是怎么优化的

这次改动尽量保持行为不变，只调整内部实现：

- GC 触发改成周期性触发，不再在过阈值后永久停留在热路径上。
- 结果清理改成原地删除过期项，不再先整体复制一份结果字典。
- cleanup 线程只启动一次，避免 allocator 重启时重复拉起清理线程。
- 本地 scheduler 增加运行中任务名索引，同名任务检查不再每次临时重建集合。
- 队列消费改成更直接的阻塞 / 事件驱动方式，减少不必要的唤醒和 queue peek。

## 我刻意没有改的东西

这次范围控制得比较窄，以下内容都没有改：

- 没有新增功能
- 没有改 public API
- 没有改优先级语义
- 没有改 RPC / proxy / result-server / Web UI 行为
- 没有引入新的运行时依赖

## 验证

我补了一组针对这次优化点的回归测试，主要覆盖：

- GC 阈值行为
- 结果清理是否保持原地处理
- 本地 scheduler 对同名任务的拒绝逻辑

实际执行过的验证命令：

- `python -m unittest tests.test_local_scheduler_performance -v`
- `python -m compileall task_scheduling tests`
- `python -c "import types, sys, loguru; sys.modules['dill']=types.SimpleNamespace(dumps=lambda x: x, loads=lambda x: x); loguru.logger.add=lambda *a, **k: 1; loguru.logger.remove=lambda *a, **k: None; import task_scheduling.manager.scheduler_manager; import task_scheduling.scheduler.api; import task_scheduling.scheduler.io_liner_task; import task_scheduling.scheduler.cpu_liner_task; import task_scheduling.scheduler.cpu_asyncio_task; import task_scheduling.scheduler.io_asyncio_task; print('imports ok')"`