### PR TITLE
fix: 修复调度器代码审查暴露的行为问题

### DIFF
--- a/docs/superpowers/plans/2026-04-04-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-04-code-review-fixes.md
@@ -1,0 +1,67 @@
+# Code Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix real behavior bugs found during code review without expanding the project's capability boundary.
+
+**Architecture:** Add focused regression tests around the scheduler status and priority handoff behavior, then make the smallest code changes needed in the existing scheduler implementations. Keep all fixes inside the current scheduling model and avoid API redesign.
+
+**Tech Stack:** Python, `unittest`, existing scheduler modules
+
+---
+
+### Task 1: Add Regression Tests For Review Findings
+
+**Files:**
+- Create: `tests/test_code_review_fixes.py`
+- Modify: `task_scheduling/scheduler/io_liner_task.py`
+- Modify: `task_scheduling/scheduler/cpu_liner_task.py`
+- Modify: `task_scheduling/scheduler/timer_task.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class CodeReviewFixTests(unittest.TestCase):
+    def test_io_linear_high_priority_task_can_preempt_when_full(self):
+        ...
+
+    def test_cpu_linear_high_priority_task_can_preempt_when_full(self):
+        ...
+
+    def test_timer_resume_uses_timer_task_type(self):
+        ...
+
+    def test_io_linear_done_marks_unhandled_errors_as_failed(self):
+        ...
+
+    def test_timer_done_marks_unhandled_errors_as_failed(self):
+        ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.test_code_review_fixes -v`
+Expected: high priority insertion test fails, timer resume task type test fails, and failed/cancelled status tests fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# io_liner_task.py / cpu_liner_task.py
+# Only reject full schedulers when the task is not eligible for high-priority preemption.
+
+# timer_task.py
+# Report resume status with task_type="timer_task"
+# Report unexpected future exceptions as status="failed"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.test_code_review_fixes -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_code_review_fixes.py task_scheduling/scheduler/io_liner_task.py task_scheduling/scheduler/cpu_liner_task.py task_scheduling/scheduler/timer_task.py docs/superpowers/plans/2026-04-04-code-review-fixes.md
+git commit -m "fix: correct scheduler review regressions"
+```

--- a/task_scheduling/scheduler/cpu_liner_task.py
+++ b/task_scheduling/scheduler/cpu_liner_task.py
@@ -224,16 +224,19 @@ class CpuLinerTask:
                 running_task_names = {details[1] for details in self._running_tasks.values()}
                 if queue_size >= config["cpu_liner_task"] or len(self._running_tasks) >= config["cpu_liner_task"]:
                     if not _task_counter.is_high_priority(priority):
-                        if _task_counter.is_high_priority_full(config["cpu_liner_task"]):
-                            return False
-                        need_add_high = True
-                    return False
+                        return False
+
+                    if _task_counter.is_high_priority_full(config["cpu_liner_task"]):
+                        return False
+
+                    need_add_high = True
 
                 if task_name in running_task_names:
                     return False
 
             if need_add_high:
-                _task_counter.add_high_priority_task(task_id, self._running_tasks)
+                if not _task_counter.add_high_priority_task(task_id, self._running_tasks):
+                    return False
 
             # 2. Status updates (queue is thread-safe)
             shared_status_info_liner.task_status_queue.put(("waiting", task_id, None, None, None, None, None))

--- a/task_scheduling/scheduler/io_liner_task.py
+++ b/task_scheduling/scheduler/io_liner_task.py
@@ -165,18 +165,21 @@ class IoLinerTask:
 
                 if queue_size >= config["io_liner_task"] or len(self._running_tasks) >= config[
                     "io_liner_task"]:
-                    if _task_counter.is_high_priority(priority):
-                        if _task_counter.is_high_priority_full(config["io_liner_task"]):
-                            return False
-                        # Prevent circular locking
-                        need_add_high = True
-                    return False
+                    if not _task_counter.is_high_priority(priority):
+                        return False
+
+                    if _task_counter.is_high_priority_full(config["io_liner_task"]):
+                        return False
+
+                    # Pause a low-priority task outside the scheduler lock to avoid re-entrancy issues.
+                    need_add_high = True
 
                 if task_name in running_task_names:
                     return False
 
             if need_add_high:
-                _task_counter.add_high_priority_task(task_id, self._running_tasks)
+                if not _task_counter.add_high_priority_task(task_id, self._running_tasks):
+                    return False
 
             # Scheduler state handling (protected by scheduler_lock)
             with self._scheduler_lock:
@@ -333,7 +336,7 @@ class IoLinerTask:
 
         except Exception as error:
             # Other exceptions have already been handled in _execute_task.
-            task_status_manager.add_task_status(task_id, None, "cancelled", None, None, error, None, None)
+            task_status_manager.add_task_status(task_id, None, "failed", None, None, error, None, None)
             result = "failed action"
 
         finally:

--- a/task_scheduling/scheduler/timer_task.py
+++ b/task_scheduling/scheduler/timer_task.py
@@ -368,7 +368,7 @@ class TimerTask:
 
         except Exception as error:
             # Other exceptions are already handled in _execute_task
-            task_status_manager.add_task_status(task_id, None, "cancelled", None, None, error, None, None)
+            task_status_manager.add_task_status(task_id, None, "failed", None, None, error, None, None)
             result = "failed action"
 
         finally:
@@ -551,7 +551,7 @@ class TimerTask:
 
         try:
             _task_manager.resume_task(task_id)
-            task_status_manager.add_task_status(task_id, None, "running", None, None, None, None, "io_liner_task")
+            task_status_manager.add_task_status(task_id, None, "running", None, None, None, None, "timer_task")
             logger.info(f"task | {task_id} | resumed")
             return True
         except Exception as error:

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -1,0 +1,135 @@
+import queue
+import sys
+import types
+import unittest
+from concurrent.futures import Future
+from unittest.mock import patch
+
+
+class _FakeLogger:
+    def add(self, *args, **kwargs):
+        return 1
+
+    def remove(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    info = debug
+    warning = debug
+    error = debug
+    critical = debug
+
+
+if "dill" not in sys.modules:
+    sys.modules["dill"] = types.SimpleNamespace(
+        dumps=lambda obj, *args, **kwargs: obj,
+        loads=lambda obj, *args, **kwargs: obj,
+    )
+
+if "loguru" not in sys.modules:
+    sys.modules["loguru"] = types.SimpleNamespace(logger=_FakeLogger())
+
+from task_scheduling.common import ensure_config_loaded
+from task_scheduling.scheduler.utils.priority_check import TaskCounter
+
+ensure_config_loaded()
+
+import task_scheduling.scheduler.cpu_liner_task as cpu_liner_module
+import task_scheduling.scheduler.io_liner_task as io_liner_module
+import task_scheduling.scheduler.timer_task as timer_module
+
+
+def _dummy_task():
+    return "ok"
+
+
+class CodeReviewFixTests(unittest.TestCase):
+    def test_io_linear_high_priority_task_can_preempt_when_full(self):
+        scheduler = io_liner_module.IoLinerTask()
+        scheduler._running_tasks["low-1"] = [Future(), "low-task", "low"]
+        task_counter = TaskCounter("io_liner_task")
+
+        with patch.dict(io_liner_module.config, {"io_liner_task": 1}, clear=False), \
+                patch.object(io_liner_module, "_task_counter", task_counter), \
+                patch("task_scheduling.scheduler.api.pause_api", return_value=True) as pause_api, \
+                patch.object(type(io_liner_module.task_status_manager), "add_task_status"), \
+                patch.object(io_liner_module.IoLinerTask, "_start_scheduler"), \
+                patch.object(io_liner_module.IoLinerTask, "_cancel_idle_timer"):
+            state = scheduler.add_task(False, "high-task", "high-1", _dummy_task, "high")
+
+        self.assertTrue(state)
+        self.assertEqual(task_counter.get_high_priority_count(), 1)
+        self.assertEqual(task_counter.get_paused_queue(), ["low-1"])
+        self.assertEqual(scheduler._task_queue.qsize(), 1)
+        pause_api.assert_called_once_with("io_liner_task", "low-1")
+
+    def test_cpu_linear_high_priority_task_can_preempt_when_full(self):
+        scheduler = cpu_liner_module.CpuLinerTask()
+        scheduler._running_tasks["low-1"] = [Future(), "low-task", "low"]
+        task_counter = TaskCounter("cpu_liner_task")
+        shared_status = types.SimpleNamespace(task_status_queue=queue.Queue())
+
+        with patch.dict(cpu_liner_module.config, {"cpu_liner_task": 1}, clear=False), \
+                patch.object(cpu_liner_module, "_task_counter", task_counter), \
+                patch.object(cpu_liner_module, "shared_status_info_liner", shared_status), \
+                patch("task_scheduling.scheduler.api.pause_api", return_value=True) as pause_api, \
+                patch.object(cpu_liner_module.CpuLinerTask, "_start_scheduler"), \
+                patch.object(cpu_liner_module.CpuLinerTask, "_cancel_idle_timer"):
+            state = scheduler.add_task(False, "high-task", "high-1", _dummy_task, "high")
+
+        self.assertTrue(state)
+        self.assertEqual(task_counter.get_high_priority_count(), 1)
+        self.assertEqual(task_counter.get_paused_queue(), ["low-1"])
+        self.assertEqual(scheduler._task_queue.qsize(), 1)
+        pause_api.assert_called_once_with("cpu_liner_task", "low-1")
+
+    def test_timer_resume_uses_timer_task_type(self):
+        scheduler = timer_module.TimerTask()
+        scheduler._running_tasks["timer-1"] = [object(), "timer-task"]
+
+        with patch.object(type(timer_module._task_manager), "resume_task"), \
+                patch.object(type(timer_module.task_status_manager), "add_task_status") as add_status:
+            state = scheduler.resume_task("timer-1")
+
+        self.assertTrue(state)
+        self.assertEqual(add_status.call_count, 1)
+        self.assertEqual(add_status.call_args.args[-1], "timer_task")
+
+    def test_io_linear_done_marks_unhandled_errors_as_failed(self):
+        scheduler = io_liner_module.IoLinerTask()
+        future = Future()
+        future.set_exception(RuntimeError("boom"))
+        scheduler._running_tasks["task-1"] = [future, "task-name", "low"]
+
+        fake_counter = types.SimpleNamespace(remove_high_priority_task=lambda task_id: None)
+
+        with patch.object(io_liner_module, "_task_counter", fake_counter), \
+                patch.object(type(io_liner_module.task_status_manager), "add_task_status") as add_status, \
+                patch.object(io_liner_module.IoLinerTask, "_reset_idle_timer"), \
+                patch.dict(io_liner_module.config, {"network_storage_results": False}, clear=False):
+            scheduler._task_done("task-1", future)
+
+        self.assertEqual(add_status.call_count, 1)
+        self.assertEqual(add_status.call_args.args[2], "failed")
+        self.assertEqual(scheduler._task_results["task-1"][0], "failed action")
+
+    def test_timer_done_marks_unhandled_errors_as_failed(self):
+        scheduler = timer_module.TimerTask()
+        future = Future()
+        future.set_exception(RuntimeError("boom"))
+        scheduler._running_tasks["task-1"] = [future, "task-name"]
+
+        with patch.object(type(timer_module.task_status_manager), "add_task_status") as add_status, \
+                patch.object(timer_module.TimerTask, "_reset_idle_timer"), \
+                patch.dict(timer_module.config, {"network_storage_results": False}, clear=False):
+            scheduler._task_done("task-1", False, "task-name", _dummy_task, (), {}, future)
+
+        self.assertEqual(add_status.call_count, 1)
+        self.assertEqual(add_status.call_args.args[2], "failed")
+        self.assertEqual(scheduler._task_results["task-1"][0], "failed action")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

这个 PR 只修复代码审查中确认的行为问题，不扩展项目能力边界，也不改变原有调度模型。

## 本次修复

1. 修复 `io_liner_task` / `cpu_liner_task` 在线程池或进程池已满时，高优先级任务无法按设计插队的问题。
   之前的实现会在设置高优先级分支后直接 `return False`，导致暂停低优先级任务的逻辑永远走不到。
   现在只有普通优先级任务会在满载时被直接拒绝；高优先级任务会先尝试暂停一个低优先级任务，再继续入队。

2. 修复 `timer_task.resume_task()` 恢复任务时上报了错误 `task_type` 的问题。
   之前这里写成了 `io_liner_task`，会让状态查询和 UI 看到错误的任务类型。

3. 修复 `io_liner_task` / `timer_task` 在 `Future` 收尾阶段遇到未处理异常时，将失败状态误记为 `cancelled` 的问题。
   现在会和其它调度器保持一致，正确上报为 `failed`。

## 验证

- 新增 5 个回归测试，覆盖高优先级插队、timer 恢复类型、失败状态上报。
- `python -m unittest discover -s tests -p "test_code_review_fixes.py" -v`
- `python -m compileall task_scheduling tests`
- 关键模块导入烟测通过