### PR TITLE
fix: 修复客户端与网络入口的审查遗留问题

### DIFF
--- a/docs/local/task_disabling.md
+++ b/docs/local/task_disabling.md
@@ -6,7 +6,7 @@ remove_ban_task_name(task_name: str) -> None
 
 - 警告:
 
-已经进入调度器的任务将不会被处理，只有在任务状态为`queued`才会被取消
+已经进入调度器的任务将不会被处理，只有在任务状态为`queuing`才会被取消
 
 - 参数说明:
 
@@ -56,7 +56,7 @@ cancel_the_queue_task_by_name(task_name: str) -> None
 
 - 警告:
 
-已经进入调度器的任务将不会被处理，只有在任务状态为`queued`才会被取消
+已经进入调度器的任务将不会被处理，只有在任务状态为`queuing`才会被取消
 
 - 参数说明:
 

--- a/docs/network/task_disabling.md
+++ b/docs/network/task_disabling.md
@@ -6,7 +6,7 @@ remove_ban_task_name(task_name: str) -> None
 
 - 警告:
 
-已经进入调度器的任务将不会被处理，只有在任务状态为`queued`才会被取消
+已经进入调度器的任务将不会被处理，只有在任务状态为`queuing`才会被取消
 
 - 参数说明:
 
@@ -53,7 +53,7 @@ cancel_the_queue_task_by_name(task_name: str) -> None
 
 - 警告:
 
-已经进入调度器的任务将不会被处理，只有在任务状态为`queued`才会被取消
+已经进入调度器的任务将不会被处理，只有在任务状态为`queuing`才会被取消
 
 - 参数说明:
 

--- a/docs/superpowers/plans/2026-04-04-client-network-review-followup.md
+++ b/docs/superpowers/plans/2026-04-04-client-network-review-followup.md
@@ -1,0 +1,65 @@
+# Client Network Review Follow-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix client and network entrypoint issues found during code review without expanding the scheduler capability boundary.
+
+**Architecture:** Add focused regression tests around invalid `function_type` handling and RPC client configuration, then make the smallest code changes needed to reject unsupported task types early and align public documentation with the real API. Keep scheduler behavior for valid inputs unchanged.
+
+**Tech Stack:** Python, `unittest`, existing client/server/task modules
+
+---
+
+### Task 1: Add Regression Tests For Client And Network Entry Points
+
+**Files:**
+- Create: `tests/test_client_network_review_followup.py`
+- Modify: `task_scheduling/task_creation.py`
+- Modify: `task_scheduling/main_server/utils/core.py`
+- Modify: `task_scheduling/client/rpc_client.py`
+- Modify: `task_scheduling/client/submit.py`
+- Modify: `docs/local/task_disabling.md`
+- Modify: `docs/network/task_disabling.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class ClientNetworkReviewFollowupTests(unittest.TestCase):
+    def test_task_creation_rejects_unsupported_function_type(self):
+        ...
+
+    def test_network_task_submit_rejects_unsupported_function_type(self):
+        ...
+
+    def test_execute_received_task_does_not_log_success_when_submission_fails(self):
+        ...
+
+    def test_rpc_client_reads_control_port_from_config(self):
+        ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m unittest discover -s tests -p "test_client_network_review_followup.py" -v`
+Expected: invalid `function_type` tests fail and RPC client config test fails because it reads `control_ip`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# Reject unsupported function_type values at local and network submission entrypoints.
+# Only log network submission success when scheduling really succeeds.
+# Read RPC client port from config["control_port"].
+# Update public docstrings and task-disabling docs to match actual values/status names.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m unittest discover -s tests -p "test_client_network_review_followup.py" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_client_network_review_followup.py task_scheduling/task_creation.py task_scheduling/main_server/utils/core.py task_scheduling/client/rpc_client.py task_scheduling/client/submit.py docs/local/task_disabling.md docs/network/task_disabling.md docs/superpowers/plans/2026-04-04-client-network-review-followup.md
+git commit -m "fix: harden client and network task validation"
+```

--- a/task_scheduling/client/rpc_client.py
+++ b/task_scheduling/client/rpc_client.py
@@ -28,7 +28,7 @@ class RPCClient:
         """
         self._socket = None
         self.host = config["control_host"]
-        self.port = config["control_ip"]
+        self.port = config["control_port"]
         self._network = NetworkHandler()
         self._socket: socket.socket
         self._connected = False

--- a/task_scheduling/client/submit.py
+++ b/task_scheduling/client/submit.py
@@ -81,9 +81,9 @@ def create_task_data(
         function_name: Name of the function to execute
         delay: Optional delay in seconds before execution
         daily_time: Optional daily scheduled time string (HH:MM format)
-        function_type: Type classification of function (default: "normal")
+        function_type: Type classification of function ("io", "cpu", or "timer")
         timeout_processing: Flag indicating if timeout processing is enabled
-        priority: Task priority level (default: "normal")
+        priority: Task priority level ("low" or "high")
         *args: Positional arguments to pass to the function
         **kwargs: Keyword arguments to pass to the function
 
@@ -145,11 +145,11 @@ def submit_task(
     Args:
         delay: Delay execution time in seconds (None for immediate execution)
         daily_time: Daily scheduled time in "HH:MM" format for recurring tasks
-        function_type: Type of function ("normal", "periodic", "scheduled")
+        function_type: Type of function ("io", "cpu", "timer")
         timeout_processing: Whether to enable timeout processing for long-running tasks
         task_name: Descriptive name for the task for monitoring purposes
         func: Callable function to execute (must be provided for execution)
-        priority: Task priority level ("low", "normal", "high", "critical")
+        priority: Task priority level ("low", "high")
         *args: Positional arguments to pass to the function
         **kwargs: Keyword arguments to pass to the function
 

--- a/task_scheduling/main_server/utils/core.py
+++ b/task_scheduling/main_server/utils/core.py
@@ -17,7 +17,7 @@ import dill
 from task_scheduling.common import logger, config
 from task_scheduling.manager import task_scheduler
 from task_scheduling.server_webui import get_tasks_info, start_task_status_ui
-from task_scheduling.utils import is_async_function
+from task_scheduling.utils import is_async_function, is_valid_function_type
 
 
 class NetworkUtils:
@@ -318,7 +318,7 @@ class ServerHealthMonitor:
 
 def task_submit(task_id: str, delay: Union[int, None], daily_time: Union[str, None], function_type: str,
                 timeout_processing: bool, task_name: str, func: Callable, priority: str,
-                *args, **kwargs) -> None:
+                *args, **kwargs) -> bool:
     """
     Submit task to queue.
 
@@ -333,19 +333,28 @@ def task_submit(task_id: str, delay: Union[int, None], daily_time: Union[str, No
         priority: Task priority
         args: Positional arguments
         kwargs: Keyword arguments
+
+    Returns:
+        bool: Whether the task was accepted for scheduling
     """
+    if not is_valid_function_type(function_type):
+        logger.error("Unsupported function type. Please use 'io', 'cpu', or 'timer'.")
+        return False
+
     async_function = is_async_function(func)
     if async_function and not function_type == "timer":
-        task_scheduler.add_task(None, None, async_function, function_type, timeout_processing,
-                                task_name, task_id, func, priority, *args, **kwargs)
+        return task_scheduler.add_task(None, None, async_function, function_type, timeout_processing,
+                                       task_name, task_id, func, priority, *args, **kwargs)
 
     if not async_function and not function_type == "timer":
-        task_scheduler.add_task(None, None, async_function, function_type, timeout_processing,
-                                task_name, task_id, func, priority, *args, **kwargs)
+        return task_scheduler.add_task(None, None, async_function, function_type, timeout_processing,
+                                       task_name, task_id, func, priority, *args, **kwargs)
 
     if function_type == "timer":
-        task_scheduler.add_task(delay, daily_time, async_function, function_type, timeout_processing,
-                                task_name, task_id, func, priority, *args, **kwargs)
+        return task_scheduler.add_task(delay, daily_time, async_function, function_type, timeout_processing,
+                                       task_name, task_id, func, priority, *args, **kwargs)
+
+    return False
 
 
 class TaskServerCore:
@@ -379,9 +388,9 @@ class TaskServerCore:
             # Get task scheduling parameters
             delay = task_data.get('delay')
             daily_time = task_data.get('daily_time')
-            function_type = task_data.get('function_type', 'normal')
+            function_type = task_data.get('function_type')
             timeout_processing = task_data.get('timeout_processing', False)
-            priority = task_data.get('priority', 'normal')
+            priority = task_data.get('priority', 'low')
 
             # Validate required parameters
             if not function_code or not function_name:
@@ -400,12 +409,15 @@ class TaskServerCore:
                 return
 
             # Submit task to scheduler
-            task_submit(
+            submitted = task_submit(
                 task_id, delay, daily_time, function_type, timeout_processing,
                 task_name, func, priority, *args, **kwargs
             )
 
-            logger.info(f"Task '{task_name}' submitted successfully")
+            if submitted:
+                logger.info(f"Task '{task_name}' submitted successfully")
+            else:
+                logger.error(f"Task '{task_name}' was rejected by the scheduler")
 
         except Exception as e:
             logger.error(f"Task execution failed: {e}")

--- a/task_scheduling/manager/scheduler_manager.py
+++ b/task_scheduling/manager/scheduler_manager.py
@@ -14,6 +14,7 @@ from typing import Callable, List, Optional, Union
 
 from task_scheduling.common import logger
 from task_scheduling.manager import task_status_manager
+from task_scheduling.utils import is_valid_function_type
 
 
 class TaskScheduler:
@@ -79,6 +80,11 @@ class TaskScheduler:
             if function_type is None:
                 logger.warning(
                     f"Task name '{task_name}' has no function type, tasks cannot be added!")
+                return False
+
+            if not is_valid_function_type(function_type):
+                logger.warning(
+                    f"Task name '{task_name}' has unsupported function type '{function_type}', tasks cannot be added!")
                 return False
 
             self.core_task_queue.put((delay,

--- a/task_scheduling/task_creation.py
+++ b/task_scheduling/task_creation.py
@@ -11,7 +11,7 @@ from typing import Callable, Union
 
 from task_scheduling.common import logger
 from task_scheduling.manager import task_scheduler
-from task_scheduling.utils import is_async_function, wait_branch_thread_ended_check
+from task_scheduling.utils import is_async_function, is_valid_function_type, wait_branch_thread_ended_check
 
 
 def task_creation(delay: Union[int, None], daily_time: Union[str, None], function_type: str, timeout_processing: bool,
@@ -34,6 +34,10 @@ def task_creation(delay: Union[int, None], daily_time: Union[str, None], functio
     :param kwargs: Keyword arguments for the task function.
     :return: A unique task ID.
     """
+    if not is_valid_function_type(function_type):
+        logger.error("Unsupported function type. Please use FUNCTION_TYPE_IO, FUNCTION_TYPE_CPU, or FUNCTION_TYPE_TIMER.")
+        return False
+
     # Generate a unique task ID
     task_id = str(uuid.uuid4())
     async_function = is_async_function(func)

--- a/task_scheduling/utils/__init__.py
+++ b/task_scheduling/utils/__init__.py
@@ -9,8 +9,9 @@ import sys
 try:
     from task_scheduling.utils.sleep import interruptible_sleep
     from task_scheduling.utils.random import random_name
-    from task_scheduling.utils.check import is_async_function, wait_branch_thread_ended_check
+    from task_scheduling.utils.check import is_async_function, is_valid_function_type, wait_branch_thread_ended_check
 except KeyboardInterrupt:
     sys.exit(0)
 
-__all__ = ['interruptible_sleep', 'random_name', 'is_async_function', 'wait_branch_thread_ended_check']
+__all__ = ['interruptible_sleep', 'random_name', 'is_async_function', 'is_valid_function_type',
+           'wait_branch_thread_ended_check']

--- a/task_scheduling/utils/check.py
+++ b/task_scheduling/utils/check.py
@@ -11,6 +11,9 @@ import inspect
 from typing import Callable
 
 
+SUPPORTED_FUNCTION_TYPES = ("io", "cpu", "timer")
+
+
 def is_async_function(func: Callable) -> bool:
     """
     Determine if a function is an asynchronous function.
@@ -22,6 +25,19 @@ def is_async_function(func: Callable) -> bool:
         True if the function is asynchronous, otherwise False.
     """
     return inspect.iscoroutinefunction(func)
+
+
+def is_valid_function_type(function_type: str) -> bool:
+    """
+    Check whether the provided function type is supported by the scheduler.
+
+    Args:
+        function_type: Function type string to validate.
+
+    Returns:
+        True if the function type is one of the supported scheduler types.
+    """
+    return function_type in SUPPORTED_FUNCTION_TYPES
 
 
 def wait_branch_thread_ended_check(func: Callable) -> bool:

--- a/tests/test_client_network_review_followup.py
+++ b/tests/test_client_network_review_followup.py
@@ -1,0 +1,124 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.info_calls = []
+        self.error_calls = []
+
+    def add(self, *args, **kwargs):
+        return 1
+
+    def remove(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def critical(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        self.info_calls.append((args, kwargs))
+
+    def error(self, *args, **kwargs):
+        self.error_calls.append((args, kwargs))
+
+
+if "dill" not in sys.modules:
+    sys.modules["dill"] = types.SimpleNamespace(
+        dumps=lambda obj, *args, **kwargs: obj,
+        loads=lambda obj, *args, **kwargs: obj,
+        UnpicklingError=ValueError,
+    )
+
+if "loguru" not in sys.modules:
+    sys.modules["loguru"] = types.SimpleNamespace(logger=_FakeLogger())
+
+from task_scheduling.common import ensure_config_loaded
+
+ensure_config_loaded()
+
+import task_scheduling.client.rpc_client as rpc_client_module
+import task_scheduling.main_server.utils.core as core_module
+import task_scheduling.task_creation as task_creation_module
+
+
+def _dummy_task():
+    return "ok"
+
+
+class _FakeScheduler:
+    def __init__(self):
+        self.calls = []
+
+    def add_task(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return True
+
+
+class ClientNetworkReviewFollowupTests(unittest.TestCase):
+    def test_task_creation_rejects_unsupported_function_type(self):
+        fake_scheduler = _FakeScheduler()
+
+        with patch.object(task_creation_module, "task_scheduler", fake_scheduler), \
+                patch.object(task_creation_module.logger, "error") as error_log:
+            state = task_creation_module.task_creation(
+                None, None, "normal", False, "demo-task", _dummy_task, "low"
+            )
+
+        self.assertFalse(state)
+        self.assertEqual(fake_scheduler.calls, [])
+        self.assertEqual(error_log.call_count, 1)
+
+    def test_network_task_submit_rejects_unsupported_function_type(self):
+        fake_scheduler = _FakeScheduler()
+
+        with patch.object(core_module, "task_scheduler", fake_scheduler), \
+                patch.object(core_module.logger, "error") as error_log:
+            state = core_module.task_submit(
+                "task-1", None, None, "normal", False, "demo-task", _dummy_task, "low"
+            )
+
+        self.assertFalse(state)
+        self.assertEqual(fake_scheduler.calls, [])
+        self.assertEqual(error_log.call_count, 1)
+
+    def test_execute_received_task_does_not_log_success_when_submission_fails(self):
+        fake_logger = _FakeLogger()
+        task_data = {
+            "function_code": "def demo_task():\n    return 'ok'\n",
+            "function_name": "demo_task",
+            "task_name": "demo-task",
+            "task_id": "task-1",
+        }
+
+        with patch.object(core_module, "start_task_status_ui"), \
+                patch.object(core_module, "logger", fake_logger), \
+                patch.object(core_module, "task_submit", return_value=False) as task_submit:
+            core = core_module.TaskServerCore()
+            core.execute_received_task(task_data)
+
+        self.assertEqual(task_submit.call_count, 1)
+        self.assertEqual(len(fake_logger.info_calls), 0)
+
+    def test_rpc_client_reads_control_port_from_config(self):
+        with patch.dict(rpc_client_module.config, {
+            "control_host": "127.0.0.1",
+            "control_port": 8300,
+            "control_ip": 9999,
+        }, clear=False):
+            client = rpc_client_module.RPCClient()
+
+        self.assertEqual(client.host, "127.0.0.1")
+        self.assertEqual(client.port, 8300)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

这是代码审查的第三轮 follow-up，范围只放在客户端和网络入口层，不涉及调度器能力扩展。

## 本次修复

1. 修复 `RPCClient` 读取控制端口时使用了错误配置键的问题。
   之前代码读取的是 `config["control_ip"]`，但配置文件里实际只有 `control_port`，会导致 RPC 客户端初始化异常或使用错误端口。

2. 为本地任务创建和网络任务提交增加 `function_type` 校验。
   之前如果传入了不支持的 `function_type`，本地接口可能会返回一个看起来成功的 task id，网络路径还可能把非法类型塞进总调度器，造成任务被反复回塞。
   现在非法类型会在入口层被直接拒绝，并记录明确错误日志。

3. 修复网络任务在提交失败时仍然记录“submitted successfully”的误导性日志。
   现在只有调度器真正接受任务时才会记录提交成功。

4. 同步公开文档和注释中的真实取值。
   - `client.submit_task()` 文档现在改为和实现一致的 `function_type` / `priority` 取值。
   - 任务禁用文档中的状态名由 `queued` 改为实际使用的 `queuing`。

## 验证

- 新增 4 个回归测试，覆盖非法 `function_type` 拒绝、网络提交失败不再误报成功、RPCClient 端口读取。
- `python -m unittest discover -s tests -p "test_client_network_review_followup.py" -v`
- `python -m compileall task_scheduling tests`
- 关键模块导入烟测通过