### PR TITLE
fix: 修复 RPC 与控制入口的审查问题

### DIFF
--- a/docs/superpowers/plans/2026-04-04-rpc-control-review-followup.md
+++ b/docs/superpowers/plans/2026-04-04-rpc-control-review-followup.md
@@ -1,0 +1,60 @@
+# RPC Control Review Follow-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix RPC/control-layer bugs found in review without changing scheduler capabilities.
+
+**Architecture:** Add focused regression tests around the public RPC client and Web UI startup entrypoint, then apply the smallest code changes needed to align those public APIs with the server-side implementation and documented arguments.
+
+**Tech Stack:** Python, `unittest`, existing RPC/Web UI modules
+
+---
+
+### Task 1: Add Regression Tests For RPC And Web UI Entrypoints
+
+**Files:**
+- Create: `tests/test_rpc_control_review_followup.py`
+- Modify: `task_scheduling/client/rpc_client.py`
+- Modify: `task_scheduling/server_webui/ui.py`
+- Modify: `docs/web_control.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class RpcControlReviewFollowupTests(unittest.TestCase):
+    def test_rpc_client_get_task_count_forwards_task_name(self):
+        ...
+
+    def test_start_task_status_ui_applies_host_override(self):
+        ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m unittest discover -s tests -p "test_rpc_control_review_followup.py" -v`
+Expected: `get_task_count("task1")` raises because the method signature is wrong, and `start_task_status_ui(host=...)` ignores the provided host.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# rpc_client.py
+# Make get_task_count accept task_name and forward it to the RPC server.
+
+# ui.py
+# Apply the caller-provided host override inside start_task_status_ui().
+
+# docs/web_control.md
+# Keep the public docs aligned with the corrected startup parameters.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m unittest discover -s tests -p "test_rpc_control_review_followup.py" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_rpc_control_review_followup.py task_scheduling/client/rpc_client.py task_scheduling/server_webui/ui.py docs/web_control.md docs/superpowers/plans/2026-04-04-rpc-control-review-followup.md
+git commit -m "fix: align rpc control entrypoints"
+```

--- a/docs/web_control.md
+++ b/docs/web_control.md
@@ -8,7 +8,7 @@
 from task_scheduling.server_webui import start_task_status_ui
 
 # 启动网页界面，访问: http://localhost:8000
-start_task_status_ui()
+start_task_status_ui(host="127.0.0.1", port=8000)
 ```
 
 - 功能说明

--- a/task_scheduling/client/rpc_client.py
+++ b/task_scheduling/client/rpc_client.py
@@ -16,7 +16,7 @@ class RPCClient:
     Simple RPC Client for direct function calls with proper serialization.
 
     Usage:
-        with RPCClient('localhost', 8888) as client:
+        with RPCClient() as client:
             info = client.get_tasks_info()
             client.add_ban_task_name('bad_task')
             client.pause_api('video', 'task_123')
@@ -78,26 +78,26 @@ class RPCClient:
         """
         return self._rpc_call('get_tasks_info')
 
-    def get_task_status(self, task_name: str) -> Dict[str, Any]:
+    def get_task_status(self, task_id: str) -> Dict[str, Any]:
         """
         Get status of specific task.
 
         Args:
-            task_name: Name of task
+            task_id: Task ID
 
         Returns:
             Dict[str, Any]: Task status information
         """
-        return self._rpc_call('get_task_status', task_name)
+        return self._rpc_call('get_task_status', task_id)
 
-    def get_task_count(self) -> Dict[str, int]:
+    def get_task_count(self, task_name: str) -> int:
         """
-        Get task counts by status.
+        Get the count of tasks with the specified task name.
 
         Returns:
-            Dict[str, int]: Task counts
+            int: Task count
         """
-        return self._rpc_call('get_task_count')
+        return self._rpc_call('get_task_count', task_name)
 
     def get_all_task_count(self) -> Dict[str, Any]:
         """

--- a/task_scheduling/server_webui/ui.py
+++ b/task_scheduling/server_webui/ui.py
@@ -522,6 +522,8 @@ def start_task_status_ui(host='', port=7999, max_port_attempts=100):
         TaskStatusServer: The server instance with actual port information
     """
     server = TaskStatusServer()
+    if host:
+        server.host = host  # Host override configuration
     server.port = port  # Port in override configuration
     server.max_port_attempts = max_port_attempts
     server.start()

--- a/tests/test_rpc_control_review_followup.py
+++ b/tests/test_rpc_control_review_followup.py
@@ -1,0 +1,64 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class _FakeLogger:
+    def add(self, *args, **kwargs):
+        return 1
+
+    def remove(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    info = debug
+    warning = debug
+    error = debug
+    critical = debug
+
+
+if "dill" not in sys.modules:
+    sys.modules["dill"] = types.SimpleNamespace(
+        dumps=lambda obj, *args, **kwargs: obj,
+        loads=lambda obj, *args, **kwargs: obj,
+        UnpicklingError=ValueError,
+    )
+
+if "loguru" not in sys.modules:
+    sys.modules["loguru"] = types.SimpleNamespace(logger=_FakeLogger())
+
+from task_scheduling.common import ensure_config_loaded
+
+ensure_config_loaded()
+
+import task_scheduling.client.rpc_client as rpc_client_module
+import task_scheduling.server_webui.ui as webui_module
+
+
+class RpcControlReviewFollowupTests(unittest.TestCase):
+    def test_rpc_client_get_task_count_forwards_task_name(self):
+        with patch.dict(rpc_client_module.config, {
+            "control_host": "127.0.0.1",
+            "control_ip": 8300,
+        }, clear=False), \
+                patch.object(rpc_client_module.RPCClient, "_rpc_call", return_value=2) as rpc_call:
+            client = rpc_client_module.RPCClient()
+            result = client.get_task_count("task1")
+
+        self.assertEqual(result, 2)
+        rpc_call.assert_called_once_with("get_task_count", "task1")
+
+    def test_start_task_status_ui_applies_host_override(self):
+        with patch.object(webui_module.TaskStatusServer, "start"):
+            server = webui_module.start_task_status_ui(host="0.0.0.0", port=8123, max_port_attempts=12)
+
+        self.assertEqual(server.host, "0.0.0.0")
+        self.assertEqual(server.port, 8123)
+        self.assertEqual(server.max_port_attempts, 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

这是继续代码审查后的又一轮 follow-up，这次只处理 RPC / 控制入口层的两个明确行为问题。

## 本次修复

1. 修复 `RPCClient.get_task_count()` 与服务端签名不一致的问题。
   服务端实际暴露的是 `get_task_count(task_name)`，但客户端方法之前没有参数，导致按文档调用 `client.get_task_count("task1")` 时会直接抛 `TypeError`。
   现在客户端已经改为接收 `task_name` 并正确转发给 RPC 服务端。

2. 修复 `start_task_status_ui(host=...)` 的 `host` 参数失效问题。
   之前这个公开入口只覆盖了 `port` 和 `max_port_attempts`，却完全忽略调用方传入的 `host`，实际仍然使用配置里的默认地址。
   现在传入的 host 会真正应用到 Web UI 服务器实例上。

3. 顺带同步了相关接口说明。
   - `RPCClient` 的使用示例不再展示不存在的构造参数。
   - `get_task_status()` 的参数名改成 `task_id`，和服务端实现保持一致。
   - `web_control` 示例改为展示显式的 host/port 启动方式。

## 验证

- 新增 2 个回归测试，覆盖 `get_task_count(task_name)` 转发与 `start_task_status_ui(host=...)` 覆盖生效。
- `python -m unittest discover -s tests -p "test_rpc_control_review_followup.py" -v`
- `python -m compileall task_scheduling tests`
- 关键模块导入烟测通过